### PR TITLE
Initialize Vite project with GitHub Pages build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # sune
+
+Simple Vite-powered Hello World site.
+
+## Scripts
+
+- `npm install` to install dependencies.
+- `npm run dev` to start the development server.
+- `npm run build` to build the site into the `docs/` directory for GitHub Pages.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello world</h1>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hello World</title>
+  </head>
+  <body>
+    <h1>Hello world</h1>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sune",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^7.1.2"
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    outDir: 'docs'
+  }
+})


### PR DESCRIPTION
## Summary
- scaffolded Vite-based vanilla JS site with Hello World index
- configured Vite to output production build to `docs` for GitHub Pages
- committed generated build artifacts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d196c6f2c8327831b0aaec90ebf62